### PR TITLE
aws-elb-vs-nlb: adding new markdown and making changes to cf markdown

### DIFF
--- a/_posts/2020-11-03-aws-elastic-beanstalk-vs-cloudformation-vs-opsworks-vs-codedeploy.md
+++ b/_posts/2020-11-03-aws-elastic-beanstalk-vs-cloudformation-vs-opsworks-vs-codedeploy.md
@@ -2,8 +2,8 @@
 layout:     post
 title:      Elastic Beanstalk vs Cloudformation vs Opswork vs Codedeploy - A Difference - AWS Certification
 date:       2020-11-03 18:45:00
-summary:    Let's compare the different EBS HDD Storage types
-categories:  AWS_CLOUD AWS_STORAGE
+summary:    Let's compare the different AWS services
+categories:  AWS_CLOUD
 permalink:  /aws-certification-elastic-beanstalk-cloud-formation-opswork-codedeploy-differences
 ---
 

--- a/_posts/2020-11-16-aws-elb-nlb.md
+++ b/_posts/2020-11-16-aws-elb-nlb.md
@@ -1,0 +1,35 @@
+﻿---
+layout:     post
+title:      Elastic Load Balancer (ELB) vs Network Load Balancer (NLB) - A Difference - AWS Certification
+date:       2020-11-16 15:00:00
+summary:    Let's compare the difference between Elastic Load Balancer (ELB) vs Network Load Balancer (NLB)
+categories:  AWS_CLOUD
+permalink:  /aws-certification-elastic-load-balancer-vs-network-load-balancer
+---
+# Understanding the differences between Elastic Load Balancer and Network Load Balancer
+
+In this tutorial, we will understand a basic comparison between *Elastic Load Balancer* and *Network Load Balancer*.
+
+| Attribute | Elastic load balancer (ELB) | Network load balancer (NLB) |
+|--|--|--|
+| **Protocols** | Supports HTTP and HTTPS protocols | Supports TCP, UDP, and TLS |
+| **Type** | Supports both internet-facing and internal | Supports both internet-facing and internal |
+| **Supports health check** | YES | YES |
+| **Cloudwatch logging and metrics** | YES | YES |
+| **Connection draining (or deregistration delay)** | YES | YES |
+| **Load balancing to multiple ports on same instances** | YES | YES |
+| **Configurable idle connection timeout** | YES | YES |
+| **Cross zone load balancing** | YES | YES |
+| **Stickiness (or Sticky sessions)** | YES | YES |
+| **Static IP address allocation (or the Elastic IP address)** | NO | YES |
+| **Resource-based IAM permissions** | YES | YES |
+| **Tag-based IAM permissions** | YES | YES |
+| **CIDR based routing** | YES | NO |
+| **Path-based routing** | YES | NO |
+| **Host-based routing** | YES | NO |
+| **HTTP header-based routing** | YES | NO |
+| **Query string parameter-based routing** | YES | NO |
+| **Fixed response** | YES | NO |
+| **Lambda functions as targets** | YES | NO |
+| **User authentication** | YES | NO |
+| **SSL offloading** | YES | YES |


### PR DESCRIPTION
- Adding new markdown for the differences between aws elb and nlb
- Making summary text changes to the elb-codedeploy-opswork markdown